### PR TITLE
Fixed imports to make rpc and asm module python3 compatible

### DIFF
--- a/src/bap/asm.py
+++ b/src/bap/asm.py
@@ -2,7 +2,7 @@
 
 """Disassembled instuctions"""
 
-from adt import ADT
+from .adt import ADT
 
 class Kind(ADT) : pass
 class Having_side_effects(Kind)    : pass

--- a/src/bap/rpc.py
+++ b/src/bap/rpc.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os, time, atexit
+import os, time, atexit, sys
 from signal import signal, SIGTERM
 import requests
 from subprocess import Popen
 from mmap import mmap
-from urlparse import urlparse, parse_qs
+if sys.version_info > (3, 0):
+    from urllib.parse import urlparse, parse_qs
+else:
+    from urlparse import urlparse, parse_qs
+
 from tempfile import NamedTemporaryFile
 import json
-import adt, arm, asm, bil
+from . import adt, arm, asm, bil
 
 import threading
 


### PR DESCRIPTION
Fixed import statements to appropriately import modules in python 3 environments.
Without these fixes the exposed interfaces `image` and  `disasm` won't be available in python 3 due to an import error that is thrown by rpc.py and silently discarded by __init__.py