### PR TITLE
Support Python 3.10

### DIFF
--- a/src/bap/adt.py
+++ b/src/bap/adt.py
@@ -182,7 +182,10 @@ leading to fragile and hard to support programs.
 
 """
 
-from collections import Iterable,Sequence,Mapping
+try:
+    from collections.abc import Iterable,Sequence,Mapping
+except ImportError:
+    from collections import Iterable,Sequence,Mapping
 
 class ADT(object):
     """Algebraic Data Type.

--- a/src/bap/bir.py
+++ b/src/bap/bir.py
@@ -2,7 +2,10 @@
 
 """BIR - BAP Intermediate Representation"""
 
-from collections import Sequence,Mapping
+try:
+    from collections.abc import Sequence,Mapping
+except ImportError:
+    from collections import Sequence,Mapping
 from .adt import *
 from .bil import *
 from . import noeval_parser


### PR DESCRIPTION
Importing the `Iterable`, `Sequence`, and `Mapping` ABCs directly from `collections` was deprecated in Python 3.3 and the aliases were removed in Python 3.10.

Based on other indications in this repository, I believe that the intent is still to support Python 2.7, so this PR attempts to import from the new location, but if it fails because the current Python is older than 3.3, falls back to the old location. If that's not the intent, I can remove these fallbacks.
